### PR TITLE
Make crates badge link to crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GW2 API library ![Build Status](https://img.shields.io/github/workflow/status/greaka/gw2lib/integration_test/master) ![Latest Version](https://img.shields.io/crates/v/gw2lib.svg) [![](https://img.shields.io/static/v1?label=Get%20Help&message=on%20Discord&style=flat&color=5865f2&labelColor=555&logo=discord&logoColor=fff)](https://discord.gg/bF7Mg38yrx)
+# GW2 API library ![Build Status](https://img.shields.io/github/workflow/status/greaka/gw2lib/integration_test/master) [![](https://img.shields.io/crates/v/gw2lib.svg)](https://crates.io/crates/gw2lib) [![](https://img.shields.io/static/v1?label=Get%20Help&message=on%20Discord&style=flat&color=5865f2&labelColor=555&logo=discord&logoColor=fff)](https://discord.gg/bF7Mg38yrx)
 
 **gw2lib is an API wrapper for the game Guild Wars 2**
 


### PR DESCRIPTION
Instinctively, I clicked on the badge expecting it to take me to the crates.io page but instead I just got a blank page with a badge. :(