### PR TITLE
BTreeSet for flag fields

### DIFF
--- a/model/src/authenticated.rs
+++ b/model/src/authenticated.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 use crate::{Endpoint, FixedEndpoint, TimeStamp};
 pub mod account;
 pub mod characters;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 #[serde(rename_all = "lowercase")]
 pub enum Permissions {
@@ -40,7 +41,7 @@ pub struct SubtokenDetails {
 pub struct Tokeninfo {
     pub id: String,
     pub name: String,
-    pub permissions: Vec<Permissions>,
+    pub permissions: BTreeSet<Permissions>,
     #[serde(rename = "type")]
     pub _type: TokenType,
     #[serde(flatten)]

--- a/model/src/authenticated/account.rs
+++ b/model/src/authenticated/account.rs
@@ -3,11 +3,12 @@ pub mod materials;
 pub mod wallet;
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 pub use crate::misc::worlds::WorldId;
 use crate::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 #[non_exhaustive]
 pub enum Access {
@@ -29,7 +30,7 @@ pub struct Account {
     pub guilds: Vec<String>,
     pub guild_leader: Option<Vec<String>>,
     pub created: TimeStamp,
-    pub access: Vec<Access>,
+    pub access: BTreeSet<Access>,
     pub commander: bool,
     pub fractal_level: Option<u8>,
     pub daily_ap: Option<u16>,

--- a/model/src/authenticated/characters.rs
+++ b/model/src/authenticated/characters.rs
@@ -68,7 +68,7 @@ pub struct Core {
     pub title: Option<TitleId>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum Discipline {
     Armorsmith,

--- a/model/src/items.rs
+++ b/model/src/items.rs
@@ -3,6 +3,7 @@ pub mod recipes;
 pub mod skins;
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 use crate::{
     game_mechanics::skills::SkillId,
@@ -50,7 +51,7 @@ pub enum Rarity {
     Legendary,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum Flags {
     AccountBindOnUse,
@@ -72,7 +73,7 @@ pub enum Flags {
     Unique,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum GameTypes {
     Activity,
@@ -83,7 +84,7 @@ pub enum GameTypes {
     Wvw,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum Restrictions {
     Asura,
@@ -124,7 +125,7 @@ pub enum WeightClass {
     Clothing,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum InfusionType {
     Enrichment,
@@ -134,7 +135,7 @@ pub enum InfusionType {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub struct InfusionSlot {
-    pub flags: Vec<InfusionType>,
+    pub flags: BTreeSet<InfusionType>,
     pub item_id: Option<ItemId>,
 }
 
@@ -368,7 +369,7 @@ pub enum UpgradeComponentType {
     Sigil,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum UpgradeComponentFlags {
     Axe,
@@ -396,7 +397,7 @@ pub enum UpgradeComponentFlags {
     Trinket,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum InfusionUpgradeFlags {
     Enrichment,
@@ -412,8 +413,8 @@ pub enum InfusionUpgradeFlags {
 pub struct UpgradeComponentDetails {
     #[serde(rename = "type")]
     pub _type: UpgradeComponentType,
-    pub flags: Vec<UpgradeComponentFlags>,
-    pub infusion_upgrade_flags: Vec<InfusionUpgradeFlags>,
+    pub flags: BTreeSet<UpgradeComponentFlags>,
+    pub infusion_upgrade_flags: BTreeSet<InfusionUpgradeFlags>,
     pub suffix: String,
     pub attribute_adjustment: f32,
     pub infix_upgrade: InfixUpgrade,
@@ -533,9 +534,9 @@ pub struct Item {
     pub level: u8,
     pub vendor_value: u64,
     pub default_skin: Option<SkinId>,
-    pub flags: Vec<Flags>,
-    pub game_types: Vec<GameTypes>,
-    pub restrictions: Vec<Restrictions>,
+    pub flags: BTreeSet<Flags>,
+    pub game_types: BTreeSet<GameTypes>,
+    pub restrictions: BTreeSet<Restrictions>,
     #[serde(flatten)]
     pub details: Details,
 }

--- a/model/src/items/recipes.rs
+++ b/model/src/items/recipes.rs
@@ -1,6 +1,7 @@
 pub type RecipeId = u32;
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 
 pub use crate::authenticated::characters::Discipline;
 use crate::{items::ItemId, BulkEndpoint, Endpoint, EndpointWithId};
@@ -63,7 +64,7 @@ pub enum RecipeType {
     UpgradeComponent,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(test, serde(deny_unknown_fields))]
 pub enum RecipeFlag {
     AutoLearned,
@@ -93,9 +94,9 @@ pub struct Recipe {
     output_item_id: ItemId,
     output_item_count: u16,
     time_to_craft_ms: u16,
-    disciplines: Vec<Discipline>,
+    disciplines: BTreeSet<Discipline>,
     min_rating: u16,
-    flags: Vec<RecipeFlag>,
+    flags: BTreeSet<RecipeFlag>,
     ingredients: Vec<Ingredient>,
     guild_ingredients: Option<Vec<GuildIngredient>>,
     output_upgrade_id: Option<u32>,


### PR DESCRIPTION
As discussed on Discord, use set types instead of Vec for flags (and other unique unordered fields).
It has the following advantages:
- It enforce uniqueness on the field
- Easier to check if field contains a given value instead of O(N) search (most common use of these fields I think)

I chose `BTreeSet` instead of `HashSet` to keep the `PartialOrd` traits on structs. Given the size of the sets, it shouldn't matter if it's O(1) or O(log N) anyway...

The following fields are affected:
- `Account::access`
- `InfusionSlot::flags`
- `Item::flags`
- `Item::game_types`
- `Item::restrictions`
- `Tokeninfo::permissions`
- `UpgradeComponentDetails::flags`
- `UpgradeComponentDetails::infusion_upgrade_flags`