### PR TITLE
Add enum variant `WardrobeTemplateTab` to items `UnlockType` enum

### DIFF
--- a/model/src/items.rs
+++ b/model/src/items.rs
@@ -255,6 +255,7 @@ pub enum UnlockType {
     Outfit,
     RandomUnlock,
     SharedSlot,
+    WardrobeTemplateTab,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Listing all items currently fails because item 106996 (gemstore extra fashion template) has a new "unlock_type": "WardrobeTemplateTab".

This PR adds the missing enum variant to deserialize this item.